### PR TITLE
Fix: Remove apparently invalid versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#target-branch
+
 version: 2
 
 updates:
@@ -11,7 +13,6 @@ updates:
     package-ecosystem: "composer"
     schedule:
       interval: "daily"
-    versioning-strategy: "increase"
 
   - commit-message:
       include: "scope"
@@ -23,4 +24,3 @@ updates:
     package-ecosystem: "github-actions"
     schedule:
       interval: "daily"
-    versioning-strategy: "increase"


### PR DESCRIPTION
This PR

* [x] removes an apparently invalid version-strategy configuration

💁‍♂️ Navigating to https://github.com/ergebnis/php-library-template/network/updates shows the following:

<img width="740" alt="Screen Shot 2020-06-10 at 20 54 02" src="https://user-images.githubusercontent.com/605483/84306964-85e5eb00-ab5c-11ea-81b6-73f2edef67e9.png">
