### PR TITLE
Fix: Remove merge label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -57,10 +57,6 @@ labels:
     color: "0e8a16"
     description: ""
 
-  - name: "merge"
-    color: "6f42c1"
-    description: ""
-
   - name: "question"
     color: "cc317c"
     description: ""


### PR DESCRIPTION
This pull request

* [x] removes the **merge** label