### PR TITLE
Fix: Add reference to workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,6 +5,7 @@ We are using [GitHub Actions](https://github.com/features/actions) as a continuo
 For details, take a look at the following workflow configuration files:
 
 - [`workflows/integrate.yaml`](workflows/integrate.yaml)
+- [`workflows/merge.yaml`](workflows/merge.yaml)
 - [`workflows/prune.yaml`](workflows/prune.yaml)
 - [`workflows/release.yaml`](workflows/release.yaml)
 - [`workflows/renew.yaml`](workflows/renew.yaml)


### PR DESCRIPTION
This pull request

* [x] adds a reference of the merge workflow to `CONTRIBUTING.md`