### PR TITLE
Enhancement: Use `github` output format when running `vimeo/psalm` on GitHub actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -261,7 +261,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-psalm-"
 
       - name: "Run vimeo/psalm"
-        run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
+        run: "vendor/bin/psalm --config=psalm.xml --diff --output-format=github --shepherd --show-info=false --stats --threads=4"
 
   tests:
     name: "Tests"


### PR DESCRIPTION
This pull request

* [x] uses the `github` output format when running `vimeo/psalm` on GitHub actions
