### PR TITLE
Enhancement: Log escaped mutations as GitHub annotations when running `infection/infection`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -209,7 +209,7 @@ jobs:
           dependencies: "${{ matrix.dependencies }}"
 
       - name: "Run mutation tests with Xdebug and infection/infection"
-        run: "vendor/bin/infection --configuration=infection.json"
+        run: "vendor/bin/infection --configuration=infection.json --logger-github"
 
   static-code-analysis:
     name: "Static Code Analysis"


### PR DESCRIPTION
This pull request

* [x] uses the `--github-logger` option to log escaped mutations as GitHub annotations when running `infection/infection` on GitHub Actions