### PR TITLE
Fix: Use PHP 7.4 for renew workflow

### DIFF
--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
+          - "7.4"
 
         dependencies:
           - "locked"


### PR DESCRIPTION
This pull request

* [x] uses PHP 7.4 for the renew workflow