### PR TITLE
Enhancement: Pull in `Helper` from `ergebnis/test-util`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,3 +1,7 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		-
+			message: "#^Method Ergebnis\\\\Package\\\\Test\\\\Unit\\\\ExampleTest\\:\\:faker\\(\\) is protected, but since the containing class is final, it can be private\\.$#"
+			count: 1
+			path: test/Unit/ExampleTest.php
 

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\Package\Test\Unit;
 
-use Ergebnis\Package;
-use Ergebnis\Test\Util;
+use Ergebnis\Package\Example;
+use Ergebnis\Package\Test;
 use PHPUnit\Framework;
 
 /**
@@ -24,13 +24,13 @@ use PHPUnit\Framework;
  */
 final class ExampleTest extends Framework\TestCase
 {
-    use Util\Helper;
+    use Test\Util\Helper;
 
     public function testFromNameReturnsExample(): void
     {
         $name = self::faker()->sentence;
 
-        $example = Package\Example::fromName($name);
+        $example = Example::fromName($name);
 
         self::assertSame($name, $example->name());
     }

--- a/test/Util/Helper.php
+++ b/test/Util/Helper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017-2021 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/php-package-template
+ */
+
+namespace Ergebnis\Package\Test\Util;
+
+use Faker\Factory;
+use Faker\Generator;
+
+trait Helper
+{
+    final protected static function faker(string $locale = 'en_US'): Generator
+    {
+        /**
+         * @var array<string, Generator>
+         */
+        static $fakers = [];
+
+        if (!\array_key_exists($locale, $fakers)) {
+            $faker = Factory::create($locale);
+
+            $faker->seed(9001);
+
+            $fakers[$locale] = $faker;
+        }
+
+        return $fakers[$locale];
+    }
+}


### PR DESCRIPTION
This pull request

* [x] pulls in the `Helper` from [`ergebnis/test-util`](https://github.com/ergebnis/test-util)