### PR TITLE
Enhancement: Use `--ansi` option

### DIFF
--- a/.github/actions/composer/composer/install/run.sh
+++ b/.github/actions/composer/composer/install/run.sh
@@ -3,19 +3,19 @@
 dependencies="${COMPOSER_INSTALL_DEPENDENCIES}"
 
 if [[ ${dependencies} == "lowest" ]]; then
-  composer update --no-interaction --no-progress --prefer-lowest
+  composer update --ansi --no-interaction --no-progress --prefer-lowest
 
   exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
-  composer install --no-interaction --no-progress
+  composer install --ansi --no-interaction --no-progress
 
   exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
-  composer update --no-interaction --no-progress
+  composer update --ansi --no-interaction --no-progress
 
   exit $?
 fi


### PR DESCRIPTION
This pull request

* [x] uses the `--ansi` option when installing dependencies with `composer`