### PR TITLE
Fix: Allow `ergebnis/composer-normalize` to run as `composer` plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
     }
   },
   "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    },
     "platform": {
       "php": "7.4.16"
     },


### PR DESCRIPTION
This pull request

* [x] allows`ergebnis/composer-normalize` to run as `composer` plugin

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#allow-plugins.