### PR TITLE
Fix: Do not use `--diff` option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -260,7 +260,7 @@ jobs:
         run: "mkdir -p .build/psalm"
 
       - name: "Run vimeo/psalm"
-        run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
+        run: "vendor/bin/psalm --config=psalm.xml --shepherd --show-info=false --stats --threads=4"
 
   tests:
     name: "Tests"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 	vendor/bin/phpstan --configuration=phpstan.neon --memory-limit=-1
 	mkdir -p .build/psalm
 	vendor/bin/psalm --config=psalm.xml --clear-cache
-	vendor/bin/psalm --config=psalm.xml --diff --show-info=false --stats --threads=4
+	vendor/bin/psalm --config=psalm.xml --show-info=false --stats --threads=4
 
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm


### PR DESCRIPTION
This pull request

* [x] stops using the `--diff` option when running `vimeo/psalm`

Follows #816.