### PR TITLE
Fix: Use `--allow-empty-baseline` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm
 	mkdir -p .build/phpstan
 	vendor/bin/phpstan clear-result-cache --configuration=phpstan.neon
-	echo "parameters:\n\tignoreErrors: []\n" > phpstan-baseline.neon
-	vendor/bin/phpstan --configuration=phpstan.neon --generate-baseline=phpstan-baseline.neon --memory-limit=-1 || true
+	vendor/bin/phpstan --allow-empty-baseline --configuration=phpstan.neon --generate-baseline=phpstan-baseline.neon --memory-limit=-1
 	mkdir -p .build/psalm
 	vendor/bin/psalm --config=psalm.xml --clear-cache
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml


### PR DESCRIPTION
This pull request

- [x] uses the `--allow-empty-baseline` option when regenerating the baseline for `phpstan/phpstan`

Follows https://github.com/ergebnis/php-package-template/pull/844#issuecomment-1002810041.