### PR TITLE
Fix: Enable `curl` extension

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -233,7 +233,7 @@ jobs:
         uses: "shivammathur/setup-php@2.16.0"
         with:
           coverage: "none"
-          extensions: "none, ctype, dom, json, mbstring, phar, simplexml, tokenizer, xml, xmlwriter"
+          extensions: "none, ctype, curl, dom, json, mbstring, phar, simplexml, tokenizer, xml, xmlwriter"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Determine composer cache directory"


### PR DESCRIPTION
This pull request

- [x] enables the `curl` extension when running a static code analysis with `vimeo/psalm` to allow sending reports to shepherd.dev

Follows #846.
