### PR TITLE
Fix: Configure indentation for `*.md` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ trim_trailing_whitespace = true
 [*.json]
 indent_size = 2
 
+[*.md]
+indent_size = 2
+
 [*.neon]
 indent_style = tab
 


### PR DESCRIPTION
This pull request

- [x] configures the indentation for `*.md` files