### PR TITLE
Fix: Enable `pcntl` and `posix` extensions for static code analysis

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -245,7 +245,7 @@ jobs:
         uses: "shivammathur/setup-php@2.16.0"
         with:
           coverage: "none"
-          extensions: "none, ctype, curl, dom, json, mbstring, phar, simplexml, tokenizer, xml, xmlwriter"
+          extensions: "none, ctype, curl, dom, json, mbstring, pcntl, phar, posix, simplexml, tokenizer, xml, xmlwriter"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Set up problem matchers for PHP"


### PR DESCRIPTION
This pull request

- [x] enables the `pcntl` and `posix` extensions for static code analysis