### PR TITLE
Fix: Use `codecov/codecov-action` to report coverage to `codecov.io`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,9 +60,10 @@ jobs:
         run: "vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to codecov.io"
-        env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-        run: "bash <(curl -s https://codecov.io/bash)"
+        uses: "codecov/codecov-action@v2.1.0"
+        with:
+          files: ".build/phpunit/logs/clover.xml"
+          token: "${{ secrets.CODECOV_TOKEN }}"
 
   coding-standards:
     name: "Coding Standards"


### PR DESCRIPTION
This pull request

- [x] uses [`codecov/codecov-action`](https://github.com/codecov/codecov-action) to report coverage to `codecov.io`

💁‍♂️ For reference, see https://docs.codecov.com/docs/about-the-codecov-bash-uploader.
