### PR TITLE
Fix: Configure platform when running tests with different PHP versions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -323,6 +323,10 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
+      - name: "Configure platform for composer"
+        if: "matrix.dependencies != 'locked'"
+        run: "composer config platform.php ${{ matrix.php-version }}"
+
       - name: "Install ${{ matrix.dependencies }} dependencies with composer"
         uses: "ergebnis/.github/actions/composer/install@1.3.2"
         with:


### PR DESCRIPTION
This pull request

- [x] configures the platform for `composer` when running tests with lowest and highest dependencies