### PR TITLE
Fix: Use `__FILE__` constant

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -36,7 +36,7 @@ $config->getFinder()
     ])
     ->ignoreDotFiles(false)
     ->in(__DIR__)
-    ->name('.php-cs-fixer.php');
+    ->name(__FILE__);
 
 $config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php-cs-fixer.cache');
 


### PR DESCRIPTION
This pull request

- [x] uses the `__FILE__` constant

Follows https://github.com/php/web-php/pull/559#discussion_r917249121.