### PR TITLE
Fix: Use file name, not path to file

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -36,7 +36,7 @@ $config->getFinder()
     ])
     ->ignoreDotFiles(false)
     ->in(__DIR__)
-    ->name(__FILE__);
+    ->name('.php-cs-fixer.php');
 
 $config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php-cs-fixer.cache');
 


### PR DESCRIPTION
This pull request

- [x] uses the file name, not the path to `.php-cs-fixer.php`

Reverts #999.