### PR TITLE
Fix YAML comment in GHA

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -2,7 +2,7 @@
 
 name: "Integrate"
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:


### PR DESCRIPTION
yamllint says _too few spaces before comment_ with 1 space only.

@localheinz If you agree I would repeat this in all YAML files.