### PR TITLE
Enhancement: Require and use `ergebnis/phpunit-slow-test-detector`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "ergebnis/license": "^2.1.0",
     "ergebnis/php-cs-fixer-config": "^5.3.1",
     "ergebnis/phpstan-rules": "^1.0.0",
+    "ergebnis/phpunit-slow-test-detector": "^1.0.0",
     "fakerphp/faker": "^1.21.0",
     "infection/infection": "~0.26.19",
     "phpstan/extension-installer": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "903fb7a65524810c87f8d2d719a98d09",
+    "content-hash": "671a75840e2a739cdc466dc56f056573",
     "packages": [],
     "packages-dev": [
         {
@@ -1305,6 +1305,69 @@
                 }
             ],
             "time": "2021-11-08T15:37:09+00:00"
+        },
+        {
+            "name": "ergebnis/phpunit-slow-test-detector",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/phpunit-slow-test-detector.git",
+                "reference": "5b9d29ce0f04db25c2e915cc3125ffc02d161060"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/phpunit-slow-test-detector/zipball/5b9d29ce0f04db25c2e915cc3125ffc02d161060",
+                "reference": "5b9d29ce0f04db25c2e915cc3125ffc02d161060",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0",
+                "phpunit/phpunit": "^10.0.1"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.29.0",
+                "ergebnis/data-provider": "^1.3.0",
+                "ergebnis/license": "^2.1.0",
+                "fakerphp/faker": "^1.21.0",
+                "rector/rector": "~0.15.11",
+                "vimeo/psalm": "^5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\PHPUnit\\SlowTestDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides facilities for detecting slow tests in phpunit/phpunit.",
+            "homepage": "https://github.com/ergebnis/phpunit-slow-test-detector",
+            "keywords": [
+                "detector",
+                "extension",
+                "phpunit",
+                "slow",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/phpunit-slow-test-detector/issues",
+                "source": "https://github.com/ergebnis/phpunit-slow-test-detector"
+            },
+            "time": "2023-02-03T14:37:37+00:00"
         },
         {
             "name": "fakerphp/faker",

--- a/test/Unit/phpunit.xml
+++ b/test/Unit/phpunit.xml
@@ -28,6 +28,9 @@
             <directory suffix=".php">../../src/</directory>
         </include>
     </coverage>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>.</directory>


### PR DESCRIPTION
This pull request

- [x] requires [`ergebnis/phpunit-slow-test-detector`](https://github.com/ergebnis/phpunit-slow-test-detector)
- [x] uses [`ergebnis/phpunit-slow-test-detector`](https://github.com/ergebnis/phpunit-slow-test-detector)
