### PR TITLE
Add `end_of_line` to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
Add the sixth standard variable to EC: `end_of_line`
https://spec.editorconfig.org/#supported-pairs
