### PR TITLE
Enhancement: Report abandoned packages when running `composer audit`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
       "infection/extension-installer": true,
       "phpstan/extension-installer": true
     },
+    "audit": {
+      "abandoned": "report"
+    },
     "platform": {
       "php": "8.1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -6396,5 +6396,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request

- [x] adjusts the configuration in `composer.json` to report abandoned packages when running `composer audit`

Follows https://github.com/composer/composer/pull/11639.