### PR TITLE
Fix: Allow updates of development dependencies only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,9 @@
 version: 2
 
 updates:
-  - commit-message:
+  - allow:
+      - dependency-type: "development"
+    commit-message:
       include: "scope"
       prefix: "composer"
     directory: "/"


### PR DESCRIPTION
This pull request

- [x] allows updates of development dependencies only